### PR TITLE
Prime fix

### DIFF
--- a/carmine/prime.py
+++ b/carmine/prime.py
@@ -83,7 +83,7 @@ class PrimeMBA(object):
     def _ids_for_r2(self, r1, filter_ids=True):
 
         # For speed, you might want to consider only cases where an event has occured for depth 2
-        ids_for_depth2 = r1[r1["confidence (X -> Event)"] > 0]["id"]
+        ids_for_depth2 = r1[r1["confidence (X -> Event)"] > 0]["id"].values.tolist()
 
         uniqe_column_list_of_lists = []
         for col in self.primed_data.iloc[:,:-1]:  # we dont want column "y" to be added into this
@@ -135,7 +135,7 @@ class PrimeMBA(object):
         if depth ==1:
             self.rule_df = r1
         elif depth == 2:
-            new_ids = self._ids_for_r2(r1, optimise_y_true)
+            new_ids = self._ids_for_r2(r1, filter_ids=optimise_y_true)
             r2 = pd.DataFrame(data=new_ids)
             if not r2.empty:
                 r2["id"] = r2.prod(axis=1)

--- a/carmine/prime.py
+++ b/carmine/prime.py
@@ -121,8 +121,8 @@ class PrimeMBA(object):
         df_primed = self._replace_with_prime()
         prod = df_primed.prod(axis=1)
         self.primed_data = df_primed
-        prime_list = np.array(self.prime_dict.values())
-        value_list = np.array(self.prime_dict.keys())
+        prime_list = np.array(list(self.prime_dict.values()))
+        value_list = np.array(list(self.prime_dict.keys()))
 
         r1 = pd.DataFrame(data=prime_list, columns=["id"])
 

--- a/carmine/prime.py
+++ b/carmine/prime.py
@@ -119,20 +119,17 @@ class PrimeMBA(object):
         """
 
         df_primed = self._replace_with_prime()
-        print(df_primed.head())
         prod = df_primed.prod(axis=1)
-        print(prod.head())
-        print((prod>0).all())
         self.primed_data = df_primed
-        prime_list = self.prime_dict.values()
-        value_list = self.prime_dict.keys()
+        prime_list = np.array(self.prime_dict.values())
+        value_list = np.array(self.prime_dict.keys())
 
         r1 = pd.DataFrame(data=prime_list, columns=["id"])
 
         r1["rule"] = r1["id"].replace(to_replace=prime_list, value=value_list)
         r1["depth"] = 1
 
-        id_event = np.array(prime_list)[value_list=="y=True"][0]
+        id_event = prime_list[value_list=="y=True"][0]
 
         r1 = self._MBA_calc(r1, prod, id_event)
         if depth ==1:

--- a/tests/test_prime.py
+++ b/tests/test_prime.py
@@ -25,8 +25,8 @@ class Test_PrimeMBA(unittest.TestCase):
         df_primed = m._replace_with_prime()
         prod = df_primed.prod(axis=1)
         m.primed_data = df_primed
-        prime_list = np.array(m.prime_dict.values())
-        value_list = np.array(m.prime_dict.keys())
+        prime_list = np.array(list(m.prime_dict.values()))
+        value_list = np.array(list(m.prime_dict.keys()))
 
         r1 = pd.DataFrame(data=prime_list, columns=["id"])
 
@@ -53,8 +53,8 @@ class Test_PrimeMBA(unittest.TestCase):
         df_primed = m._replace_with_prime()
         prod = df_primed.prod(axis=1)
         m.primed_data = df_primed
-        prime_list = np.array(m.prime_dict.values())
-        value_list = np.array(m.prime_dict.keys())
+        prime_list = np.array(list(m.prime_dict.values()))
+        value_list = np.array(list(m.prime_dict.keys()))
 
         r1 = pd.DataFrame(data=prime_list, columns=["id"])
         r1["rule"] = r1["id"].replace(to_replace=prime_list, value=value_list)

--- a/tests/test_prime.py
+++ b/tests/test_prime.py
@@ -11,32 +11,30 @@ from carmine.prime import PrimeMBA
 
 class Test_PrimeMBA(unittest.TestCase):
 
-    def test_primes_and_unique_list(self):
+    def test_replace_with_prime(self):
         m = PrimeMBA(X, y)
-        prime_list, F_unique = m._primes_and_unique_list()
-        self.assertIsNotNone(prime_list)
-        self.assertIsNotNone(prime_list)
-        self.assertGreater(len(prime_list), 0)
-        self.assertGreater(len(F_unique), 0)
-        self.assertIsInstance(prime_list, list)
-        self.assertIsInstance(F_unique, np.ndarray)
-
-    def test_calc_prod(self):
-        m = PrimeMBA(X, y)
-        prime_list, F_unique = m._primes_and_unique_list()
-        prod = m._calc_prod(prime_list, F_unique)
-        self.assertIsInstance(prod, pd.Series)
-        self.assertEqual(prod.shape[0], X.shape[0])
+        df_primed = m._replace_with_prime()
+        self.assertIsNotNone(df_primed)
+        self.assertEqual(df_primed.shape[0], X.shape[0])
+        self.assertEqual(df_primed.shape[1], X.shape[1] + 1)
+        self.assertEqual(df_primed.shape, m.data.shape)
+        self.assertIsInstance(df_primed, pd.DataFrame)
 
     def test_MBA_calc(self):
         m = PrimeMBA(X, y)
-        prime_list, F_unique = m._primes_and_unique_list()
-        prod = m._calc_prod(prime_list, F_unique)
+        df_primed = m._replace_with_prime()
+        prod = df_primed.prod(axis=1)
+        m.primed_data = df_primed
+        prime_list = np.array(m.prime_dict.values())
+        value_list = np.array(m.prime_dict.keys())
+
         r1 = pd.DataFrame(data=prime_list, columns=["id"])
-        r1["rule"] = r1["id"].replace(to_replace=prime_list,
-                                      value=F_unique)
+
+        r1["rule"] = r1["id"].replace(to_replace=prime_list, value=value_list)
         r1["depth"] = 1
-        id_event = np.array(prime_list)[F_unique=="y=True"][0]
+
+        id_event = prime_list[value_list=="y=True"][0]
+
         r1 = m._MBA_calc(r1, prod, id_event)
 
         self.assertIsNotNone(r1)
@@ -52,13 +50,17 @@ class Test_PrimeMBA(unittest.TestCase):
 
     def test_ids_for_r2(self):
         m = PrimeMBA(X, y)
-        prime_list, F_unique = m._primes_and_unique_list()
-        prod = m._calc_prod(prime_list, F_unique)
+        df_primed = m._replace_with_prime()
+        prod = df_primed.prod(axis=1)
+        m.primed_data = df_primed
+        prime_list = np.array(m.prime_dict.values())
+        value_list = np.array(m.prime_dict.keys())
+
         r1 = pd.DataFrame(data=prime_list, columns=["id"])
-        r1["rule"] = r1["id"].replace(to_replace=prime_list,
-                                      value=F_unique)
+        r1["rule"] = r1["id"].replace(to_replace=prime_list, value=value_list)
         r1["depth"] = 1
-        id_event = np.array(prime_list)[F_unique=="y=True"][0]
+
+        id_event = prime_list[value_list=="y=True"][0]
         r1 = m._MBA_calc(r1, prod, id_event)
 
         new_ids = m._ids_for_r2(r1, True)

--- a/tests/test_prime.py
+++ b/tests/test_prime.py
@@ -63,7 +63,7 @@ class Test_PrimeMBA(unittest.TestCase):
         id_event = prime_list[value_list=="y=True"][0]
         r1 = m._MBA_calc(r1, prod, id_event)
 
-        new_ids = m._ids_for_r2(r1, True)
+        new_ids = m._ids_for_r2(r1, filter_ids=True)
 
         self.assertIsNotNone(new_ids)
         self.assertGreater(len(new_ids), 0)


### PR DESCRIPTION
The allocation of primes were incorrect since the last changes. When decoding the rules from the primes, we would map the wrong way. This tries to fix that.